### PR TITLE
Option for using this addon when kodi isn't playing

### DIFF
--- a/service.py
+++ b/service.py
@@ -120,21 +120,40 @@ if params['action'] in ['search', 'manualsearch']:
         params['searchstring'] = urllib.unquote(params['searchstring'])
 
     item = {}
-    item['temp'] = False
-    item['rar'] = False
-    item['year'] = xbmc.getInfoLabel("VideoPlayer.Year")  # Year
-    item['season'] = str(xbmc.getInfoLabel("VideoPlayer.Season"))  # Season
-    item['episode'] = str(xbmc.getInfoLabel("VideoPlayer.Episode"))  # Episode
-    item['tvshow'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.TVshowtitle"))  # Show
-    item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.OriginalTitle"))  # try to get original title
-    item['file_original_path'] = urllib.unquote(unicode(xbmc.Player().getPlayingFile(), 'utf-8'))  # Full path of a playing file
-    item['3let_language'] = []
-    item['preferredlanguage'] = unicode(urllib.unquote(params.get('preferredlanguage', '')), 'utf-8')
-    item['preferredlanguage'] = xbmc.convertLanguage(item['preferredlanguage'], xbmc.ISO_639_2)
+    #Patch: Added and changed by burekas - Enables using the Manual Search in the subtitles dialog when no playing media.
+    if xbmc.Player().isPlaying():
+        item['temp'] = False
+        item['rar'] = False
+        item['year'] = xbmc.getInfoLabel("VideoPlayer.Year")  # Year
+        item['season'] = str(xbmc.getInfoLabel("VideoPlayer.Season"))  # Season
+        item['episode'] = str(xbmc.getInfoLabel("VideoPlayer.Episode"))  # Episode
+        item['tvshow'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.TVshowtitle"))  # Show
+        item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.OriginalTitle"))  # try to get original title
+        item['file_original_path'] = urllib.unquote(unicode(xbmc.Player().getPlayingFile(), 'utf-8'))  # Full path of a playing file
+        item['3let_language'] = []
+        item['preferredlanguage'] = unicode(urllib.unquote(params.get('preferredlanguage', '')), 'utf-8')
+        item['preferredlanguage'] = xbmc.convertLanguage(item['preferredlanguage'], xbmc.ISO_639_2)
 
+    else:
+        item['temp'] = False
+        item['rar'] = False
+        item['year'] = ""
+        item['season'] = ""
+        item['episode'] = ""
+        item['tvshow'] = ""
+        item['title'] = ""
+        item['file_original_path'] = ""
+        item['3let_language'] = []
+        item['preferredlanguage'] = unicode(urllib.unquote(params.get('preferredlanguage', '')), 'utf-8')
+        item['preferredlanguage'] = xbmc.convertLanguage(item['preferredlanguage'], xbmc.ISO_639_2)
+
+    #Patch: Added and changed by burekas - Enables using the Manual Search in the subtitles dialog when no playing media.
     if item['title'] == "":
-        log("VideoPlayer.OriginalTitle not found")
-        item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
+        if xbmc.Player().isPlaying():
+            log("VideoPlayer.OriginalTitle not found")
+            item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
+        else:
+            item['title'] = "Serach For..." # or any dump title to get No subtitle Found #burekas
 
     if params['action'] == 'manualsearch':
         if item['season'] != '' or item['episode']:

--- a/service.py
+++ b/service.py
@@ -120,7 +120,7 @@ if params['action'] in ['search', 'manualsearch']:
         params['searchstring'] = urllib.unquote(params['searchstring'])
 
     item = {}
-    #Patch: Added and changed by burekas - Enables using the Manual Search in the subtitles dialog when no playing media.
+    
     if xbmc.Player().isPlaying():
         item['temp'] = False
         item['rar'] = False
@@ -147,13 +147,12 @@ if params['action'] in ['search', 'manualsearch']:
         item['preferredlanguage'] = unicode(urllib.unquote(params.get('preferredlanguage', '')), 'utf-8')
         item['preferredlanguage'] = xbmc.convertLanguage(item['preferredlanguage'], xbmc.ISO_639_2)
 
-    #Patch: Added and changed by burekas - Enables using the Manual Search in the subtitles dialog when no playing media.
-    if item['title'] == "":
-        if xbmc.Player().isPlaying():
-            log("VideoPlayer.OriginalTitle not found")
-            item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
-        else:
-            item['title'] = "Serach For..." # or any dump title to get No subtitle Found #burekas
+
+    if item['title'] == "" and xbmc.Player().isPlaying():
+        log("VideoPlayer.OriginalTitle not found")
+        item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
+    else:
+        item['title'] = "Serach For..." # or any dump title to get "No subtitle Found" #burekas
 
     if params['action'] == 'manualsearch':
         if item['season'] != '' or item['episode']:


### PR DESCRIPTION
Add the option for using the subscenter addon when kodi is no playing
any media, by using the Manual Search button in the Subtitles Dialog.
- Open the Subtitles Dialog outside the player can be done by add it in
  the Keymap xml files.
- This patch by #burekas doesn't change the noraml operation as it today
  when kodi is playing media.
- This fix have been tested by me (burekas)
- Follow the #burekas comments where the changes have been done.
  The mainly changes are by add a condition where kodi playing or not
  playing: if xbmc.Player().isPlaying()
