### PR TITLE
Fix Download exception when kodi isn't playing

### DIFF
--- a/service.py
+++ b/service.py
@@ -23,8 +23,6 @@ __profile__ = unicode(xbmc.translatePath(__addon__.getAddonInfo('profile')), 'ut
 __resource__ = unicode(xbmc.translatePath(os.path.join(__cwd__, 'resources', 'lib')), 'utf-8')
 __temp__ = unicode(xbmc.translatePath(os.path.join(__profile__, 'temp')), 'utf-8')
 
-__isKodiPlaying__ = xbmc.Player().isPlaying()
-
 sys.path.append(__resource__)
 
 from SUBUtilities import SubscenterHelper, log, normalizeString, clear_store, parse_rls_title, clean_title
@@ -95,26 +93,21 @@ def get_params(string=""):
     return param
 
 def mirror_sub(id, filename, sub_file):
-    if __isKodiPlaying__:
-        values = {}
-        values['id'] = id
-        values['versioname'] = filename
-        values['source'] = 'subscenter'
-        values['year'] = xbmc.getInfoLabel("VideoPlayer.Year")
-        values['season'] = str(xbmc.getInfoLabel("VideoPlayer.Season"))
-        values['episode'] = str(xbmc.getInfoLabel("VideoPlayer.Episode"))
-        values['imdb'] = str(xbmc.getInfoLabel("VideoPlayer.IMDBNumber"))
-        values['tvshow'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.TVshowtitle"))
-        values['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.OriginalTitle"))
-        values['file_original_path'] = urllib.unquote(unicode(xbmc.Player().getPlayingFile(), 'utf-8'))
-
-        url = 'http://subs.thewiz.info/send.php'
-        try:
-            post(url, files={'sub': open(sub_file, 'rb')}, data=values)
-        except:
-            pass
-
-    else:
+    values = {}
+    values['id'] = id
+    values['versioname'] = filename
+    values['source'] = 'subscenter'
+    values['year'] = xbmc.getInfoLabel("VideoPlayer.Year")
+    values['season'] = str(xbmc.getInfoLabel("VideoPlayer.Season"))
+    values['episode'] = str(xbmc.getInfoLabel("VideoPlayer.Episode"))
+    values['imdb'] = str(xbmc.getInfoLabel("VideoPlayer.IMDBNumber"))
+    values['tvshow'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.TVshowtitle"))
+    values['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.OriginalTitle"))
+    values['file_original_path'] = urllib.unquote(unicode(xbmc.Player().getPlayingFile(), 'utf-8'))
+    url = 'http://subs.thewiz.info/send.php'
+    try:
+        post(url, files={'sub': open(sub_file, 'rb')}, data=values)
+    except:
         pass
 
 params = get_params()
@@ -128,7 +121,7 @@ if params['action'] in ['search', 'manualsearch']:
 
     item = {}
     
-    if __isKodiPlaying__:
+    if xbmc.Player().isPlaying():
         item['temp'] = False
         item['rar'] = False
         item['year'] = xbmc.getInfoLabel("VideoPlayer.Year")  # Year
@@ -155,11 +148,11 @@ if params['action'] in ['search', 'manualsearch']:
         item['preferredlanguage'] = xbmc.convertLanguage(item['preferredlanguage'], xbmc.ISO_639_2)
 
 
-    if item['title'] == "" and __isKodiPlaying__:
+    if item['title'] == "" and xbmc.Player().isPlaying():
         log("VideoPlayer.OriginalTitle not found")
         item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
     else:
-        item['title'] = "Search For..." # or any dump title to get "No subtitle Found" #burekas
+        item['title'] = "Serach For..." # or any dump title to get "No subtitle Found" #burekas
 
     if params['action'] == 'manualsearch':
         if item['season'] != '' or item['episode']:

--- a/service.py
+++ b/service.py
@@ -23,6 +23,8 @@ __profile__ = unicode(xbmc.translatePath(__addon__.getAddonInfo('profile')), 'ut
 __resource__ = unicode(xbmc.translatePath(os.path.join(__cwd__, 'resources', 'lib')), 'utf-8')
 __temp__ = unicode(xbmc.translatePath(os.path.join(__profile__, 'temp')), 'utf-8')
 
+__isKodiPlaying__ = xbmc.Player().isPlaying()
+
 sys.path.append(__resource__)
 
 from SUBUtilities import SubscenterHelper, log, normalizeString, clear_store, parse_rls_title, clean_title
@@ -93,21 +95,26 @@ def get_params(string=""):
     return param
 
 def mirror_sub(id, filename, sub_file):
-    values = {}
-    values['id'] = id
-    values['versioname'] = filename
-    values['source'] = 'subscenter'
-    values['year'] = xbmc.getInfoLabel("VideoPlayer.Year")
-    values['season'] = str(xbmc.getInfoLabel("VideoPlayer.Season"))
-    values['episode'] = str(xbmc.getInfoLabel("VideoPlayer.Episode"))
-    values['imdb'] = str(xbmc.getInfoLabel("VideoPlayer.IMDBNumber"))
-    values['tvshow'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.TVshowtitle"))
-    values['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.OriginalTitle"))
-    values['file_original_path'] = urllib.unquote(unicode(xbmc.Player().getPlayingFile(), 'utf-8'))
-    url = 'http://subs.thewiz.info/send.php'
-    try:
-        post(url, files={'sub': open(sub_file, 'rb')}, data=values)
-    except:
+    if __isKodiPlaying__:
+        values = {}
+        values['id'] = id
+        values['versioname'] = filename
+        values['source'] = 'subscenter'
+        values['year'] = xbmc.getInfoLabel("VideoPlayer.Year")
+        values['season'] = str(xbmc.getInfoLabel("VideoPlayer.Season"))
+        values['episode'] = str(xbmc.getInfoLabel("VideoPlayer.Episode"))
+        values['imdb'] = str(xbmc.getInfoLabel("VideoPlayer.IMDBNumber"))
+        values['tvshow'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.TVshowtitle"))
+        values['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.OriginalTitle"))
+        values['file_original_path'] = urllib.unquote(unicode(xbmc.Player().getPlayingFile(), 'utf-8'))
+
+        url = 'http://subs.thewiz.info/send.php'
+        try:
+            post(url, files={'sub': open(sub_file, 'rb')}, data=values)
+        except:
+            pass
+
+    else:
         pass
 
 params = get_params()
@@ -121,7 +128,7 @@ if params['action'] in ['search', 'manualsearch']:
 
     item = {}
     
-    if xbmc.Player().isPlaying():
+    if __isKodiPlaying__:
         item['temp'] = False
         item['rar'] = False
         item['year'] = xbmc.getInfoLabel("VideoPlayer.Year")  # Year
@@ -148,7 +155,7 @@ if params['action'] in ['search', 'manualsearch']:
         item['preferredlanguage'] = xbmc.convertLanguage(item['preferredlanguage'], xbmc.ISO_639_2)
 
 
-    if item['title'] == "" and xbmc.Player().isPlaying():
+    if item['title'] == "" and __isKodiPlaying__:
         log("VideoPlayer.OriginalTitle not found")
         item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
     else:


### PR DESCRIPTION
- Fix the error exception from kodi when downloading subtitle is done when kodi isn't playing (Added an if conditition in mirror_sub function)
- Note: When the user will press on a subtitle, the subtitle will still be downloaded to the temp folder in the addon folder in userdata (As it done currently for normal downloading when kodi is playing), after that the search subtitles dialog will be closed. But this is not should be relevant to the user for the main purpose of using it only for watching the subtitles result list.

In Addition:
- Set a new local variable **isKodiPlaying** instead of writing xbmc.Player().isPlaying() on each place.
- Fix speeling "Serach for" to "Search for..." (Ignore this, I saw that you already fix it)
