### PR TITLE
Critical Fix - If condition when title is empty

### DIFF
--- a/service.py
+++ b/service.py
@@ -148,12 +148,11 @@ if params['action'] in ['search', 'manualsearch']:
         item['preferredlanguage'] = xbmc.convertLanguage(item['preferredlanguage'], xbmc.ISO_639_2)
 
 
-    if item['title'] == "":
-        if xbmc.Player().isPlaying():
-            log("VideoPlayer.OriginalTitle not found")
-            item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
-        else:
-            item['title'] = "Search For..."  # Needed to avoid showing previous search result.
+    if item['title'] == "" and xbmc.Player().isPlaying():
+        log("VideoPlayer.OriginalTitle not found")
+        item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
+    else:
+        item['title'] = "Search For..." # Needed to avoid showing previous search result.
 
     if params['action'] == 'manualsearch':
         if item['season'] != '' or item['episode']:

--- a/service.py
+++ b/service.py
@@ -23,8 +23,6 @@ __profile__ = unicode(xbmc.translatePath(__addon__.getAddonInfo('profile')), 'ut
 __resource__ = unicode(xbmc.translatePath(os.path.join(__cwd__, 'resources', 'lib')), 'utf-8')
 __temp__ = unicode(xbmc.translatePath(os.path.join(__profile__, 'temp')), 'utf-8')
 
-__isKodiPlaying__ = xbmc.Player().isPlaying()
-
 sys.path.append(__resource__)
 
 from SUBUtilities import SubscenterHelper, log, normalizeString, clear_store, parse_rls_title, clean_title
@@ -95,26 +93,21 @@ def get_params(string=""):
     return param
 
 def mirror_sub(id, filename, sub_file):
-    if __isKodiPlaying__:
-        values = {}
-        values['id'] = id
-        values['versioname'] = filename
-        values['source'] = 'subscenter'
-        values['year'] = xbmc.getInfoLabel("VideoPlayer.Year")
-        values['season'] = str(xbmc.getInfoLabel("VideoPlayer.Season"))
-        values['episode'] = str(xbmc.getInfoLabel("VideoPlayer.Episode"))
-        values['imdb'] = str(xbmc.getInfoLabel("VideoPlayer.IMDBNumber"))
-        values['tvshow'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.TVshowtitle"))
-        values['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.OriginalTitle"))
-        values['file_original_path'] = urllib.unquote(unicode(xbmc.Player().getPlayingFile(), 'utf-8'))
-
-        url = 'http://subs.thewiz.info/send.php'
-        try:
-            post(url, files={'sub': open(sub_file, 'rb')}, data=values)
-        except:
-            pass
-
-    else:
+    values = {}
+    values['id'] = id
+    values['versioname'] = filename
+    values['source'] = 'subscenter'
+    values['year'] = xbmc.getInfoLabel("VideoPlayer.Year")
+    values['season'] = str(xbmc.getInfoLabel("VideoPlayer.Season"))
+    values['episode'] = str(xbmc.getInfoLabel("VideoPlayer.Episode"))
+    values['imdb'] = str(xbmc.getInfoLabel("VideoPlayer.IMDBNumber"))
+    values['tvshow'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.TVshowtitle"))
+    values['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.OriginalTitle"))
+    values['file_original_path'] = urllib.unquote(unicode(xbmc.Player().getPlayingFile(), 'utf-8'))
+    url = 'http://subs.thewiz.info/send.php'
+    try:
+        post(url, files={'sub': open(sub_file, 'rb')}, data=values)
+    except:
         pass
 
 params = get_params()
@@ -128,7 +121,7 @@ if params['action'] in ['search', 'manualsearch']:
 
     item = {}
     
-    if __isKodiPlaying__:
+    if xbmc.Player().isPlaying():
         item['temp'] = False
         item['rar'] = False
         item['year'] = xbmc.getInfoLabel("VideoPlayer.Year")  # Year
@@ -155,11 +148,11 @@ if params['action'] in ['search', 'manualsearch']:
         item['preferredlanguage'] = xbmc.convertLanguage(item['preferredlanguage'], xbmc.ISO_639_2)
 
 
-    if item['title'] == "" and __isKodiPlaying__:
+    if item['title'] == "" and xbmc.Player().isPlaying():
         log("VideoPlayer.OriginalTitle not found")
         item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
     else:
-        item['title'] = "Search For..." # or any dump title to get "No subtitle Found" #burekas
+        item['title'] = "Serach For..." # or any dump title to get "No subtitle Found" #burekas
 
     if params['action'] == 'manualsearch':
         if item['season'] != '' or item['episode']:

--- a/service.py
+++ b/service.py
@@ -23,6 +23,8 @@ __profile__ = unicode(xbmc.translatePath(__addon__.getAddonInfo('profile')), 'ut
 __resource__ = unicode(xbmc.translatePath(os.path.join(__cwd__, 'resources', 'lib')), 'utf-8')
 __temp__ = unicode(xbmc.translatePath(os.path.join(__profile__, 'temp')), 'utf-8')
 
+__isKodiPlaying__ = xbmc.Player().isPlaying()
+
 sys.path.append(__resource__)
 
 from SUBUtilities import SubscenterHelper, log, normalizeString, clear_store, parse_rls_title, clean_title
@@ -93,21 +95,26 @@ def get_params(string=""):
     return param
 
 def mirror_sub(id, filename, sub_file):
-    values = {}
-    values['id'] = id
-    values['versioname'] = filename
-    values['source'] = 'subscenter'
-    values['year'] = xbmc.getInfoLabel("VideoPlayer.Year")
-    values['season'] = str(xbmc.getInfoLabel("VideoPlayer.Season"))
-    values['episode'] = str(xbmc.getInfoLabel("VideoPlayer.Episode"))
-    values['imdb'] = str(xbmc.getInfoLabel("VideoPlayer.IMDBNumber"))
-    values['tvshow'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.TVshowtitle"))
-    values['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.OriginalTitle"))
-    values['file_original_path'] = urllib.unquote(unicode(xbmc.Player().getPlayingFile(), 'utf-8'))
-    url = 'http://subs.thewiz.info/send.php'
-    try:
-        post(url, files={'sub': open(sub_file, 'rb')}, data=values)
-    except:
+    if __isKodiPlaying__:
+        values = {}
+        values['id'] = id
+        values['versioname'] = filename
+        values['source'] = 'subscenter'
+        values['year'] = xbmc.getInfoLabel("VideoPlayer.Year")
+        values['season'] = str(xbmc.getInfoLabel("VideoPlayer.Season"))
+        values['episode'] = str(xbmc.getInfoLabel("VideoPlayer.Episode"))
+        values['imdb'] = str(xbmc.getInfoLabel("VideoPlayer.IMDBNumber"))
+        values['tvshow'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.TVshowtitle"))
+        values['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.OriginalTitle"))
+        values['file_original_path'] = urllib.unquote(unicode(xbmc.Player().getPlayingFile(), 'utf-8'))
+
+        url = 'http://subs.thewiz.info/send.php'
+        try:
+            post(url, files={'sub': open(sub_file, 'rb')}, data=values)
+        except:
+            pass
+
+    else:
         pass
 
 params = get_params()
@@ -121,7 +128,7 @@ if params['action'] in ['search', 'manualsearch']:
 
     item = {}
     
-    if xbmc.Player().isPlaying():
+    if __isKodiPlaying__:
         item['temp'] = False
         item['rar'] = False
         item['year'] = xbmc.getInfoLabel("VideoPlayer.Year")  # Year
@@ -148,7 +155,7 @@ if params['action'] in ['search', 'manualsearch']:
         item['preferredlanguage'] = xbmc.convertLanguage(item['preferredlanguage'], xbmc.ISO_639_2)
 
 
-    if item['title'] == "" and xbmc.Player().isPlaying():
+    if item['title'] == "" and __isKodiPlaying__:
         log("VideoPlayer.OriginalTitle not found")
         item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
     else:

--- a/service.py
+++ b/service.py
@@ -23,8 +23,6 @@ __profile__ = unicode(xbmc.translatePath(__addon__.getAddonInfo('profile')), 'ut
 __resource__ = unicode(xbmc.translatePath(os.path.join(__cwd__, 'resources', 'lib')), 'utf-8')
 __temp__ = unicode(xbmc.translatePath(os.path.join(__profile__, 'temp')), 'utf-8')
 
-__isKodiPlaying__ = xbmc.Player().isPlaying()
-
 sys.path.append(__resource__)
 
 from SUBUtilities import SubscenterHelper, log, normalizeString, clear_store, parse_rls_title, clean_title
@@ -95,26 +93,21 @@ def get_params(string=""):
     return param
 
 def mirror_sub(id, filename, sub_file):
-    if __isKodiPlaying__:
-        values = {}
-        values['id'] = id
-        values['versioname'] = filename
-        values['source'] = 'subscenter'
-        values['year'] = xbmc.getInfoLabel("VideoPlayer.Year")
-        values['season'] = str(xbmc.getInfoLabel("VideoPlayer.Season"))
-        values['episode'] = str(xbmc.getInfoLabel("VideoPlayer.Episode"))
-        values['imdb'] = str(xbmc.getInfoLabel("VideoPlayer.IMDBNumber"))
-        values['tvshow'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.TVshowtitle"))
-        values['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.OriginalTitle"))
-        values['file_original_path'] = urllib.unquote(unicode(xbmc.Player().getPlayingFile(), 'utf-8'))
-
-        url = 'http://subs.thewiz.info/send.php'
-        try:
-            post(url, files={'sub': open(sub_file, 'rb')}, data=values)
-        except:
-            pass
-
-    else:
+    values = {}
+    values['id'] = id
+    values['versioname'] = filename
+    values['source'] = 'subscenter'
+    values['year'] = xbmc.getInfoLabel("VideoPlayer.Year")
+    values['season'] = str(xbmc.getInfoLabel("VideoPlayer.Season"))
+    values['episode'] = str(xbmc.getInfoLabel("VideoPlayer.Episode"))
+    values['imdb'] = str(xbmc.getInfoLabel("VideoPlayer.IMDBNumber"))
+    values['tvshow'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.TVshowtitle"))
+    values['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.OriginalTitle"))
+    values['file_original_path'] = urllib.unquote(unicode(xbmc.Player().getPlayingFile(), 'utf-8'))
+    url = 'http://subs.thewiz.info/send.php'
+    try:
+        post(url, files={'sub': open(sub_file, 'rb')}, data=values)
+    except:
         pass
 
 params = get_params()
@@ -128,7 +121,7 @@ if params['action'] in ['search', 'manualsearch']:
 
     item = {}
     
-    if __isKodiPlaying__:
+    if xbmc.Player().isPlaying():
         item['temp'] = False
         item['rar'] = False
         item['year'] = xbmc.getInfoLabel("VideoPlayer.Year")  # Year
@@ -155,11 +148,12 @@ if params['action'] in ['search', 'manualsearch']:
         item['preferredlanguage'] = xbmc.convertLanguage(item['preferredlanguage'], xbmc.ISO_639_2)
 
 
-    if item['title'] == "" and __isKodiPlaying__:
-        log("VideoPlayer.OriginalTitle not found")
-        item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
-    else:
-        item['title'] = "Search For..." # Needed to avoid showing previous search result.
+    if item['title'] == "":
+        if xbmc.Player().isPlaying():
+            log("VideoPlayer.OriginalTitle not found")
+            item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
+        else:
+            item['title'] = "Search For..." # Needed to avoid showing previous search result.
 
     if params['action'] == 'manualsearch':
         if item['season'] != '' or item['episode']:

--- a/service.py
+++ b/service.py
@@ -141,18 +141,16 @@ if params['action'] in ['search', 'manualsearch']:
         item['season'] = ""
         item['episode'] = ""
         item['tvshow'] = ""
-        item['title'] = ""
+        item['title'] = "Search For..." # Needed to avoid showing previous search result.
         item['file_original_path'] = ""
         item['3let_language'] = []
         item['preferredlanguage'] = unicode(urllib.unquote(params.get('preferredlanguage', '')), 'utf-8')
         item['preferredlanguage'] = xbmc.convertLanguage(item['preferredlanguage'], xbmc.ISO_639_2)
 
 
-    if item['title'] == "" and xbmc.Player().isPlaying():
+    if item['title'] == "":
         log("VideoPlayer.OriginalTitle not found")
         item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
-    else:
-        item['title'] = "Search For..." # Needed to avoid showing previous search result.
 
     if params['action'] == 'manualsearch':
         if item['season'] != '' or item['episode']:

--- a/service.py
+++ b/service.py
@@ -153,7 +153,7 @@ if params['action'] in ['search', 'manualsearch']:
             log("VideoPlayer.OriginalTitle not found")
             item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
         else:
-            item['title'] = "Search For..." # Needed to avoid showing previous search result.
+            item['title'] = "Search For..."  # Needed to avoid showing previous search result.
 
     if params['action'] == 'manualsearch':
         if item['season'] != '' or item['episode']:


### PR DESCRIPTION
:: IGNORE THIS PR, SEE #11  instead, better fix ::
Salts and Local content for example gives empty title from the player, while exodus and specto gives a title. So currently in Exodus case it always goes to the "else" with the "fake" title and didn't show results.
When with salts it go into the right place and fix the title.
The fix:
The if for kodi is playing must be inside the if for empty title. So when there is a title it won't go into it at all, when the title is empty it takes the right title. The "else" will do just when the title is empty (because it set like this before) and when kodi isn't playing.

This actually as I set it at the first place.
I check this and now it's ok.

Basically there is another option, by put the "fake" title few lines before, in the first condition if kodi is playing (Instead of the empty title as it now), and bring back the if condition when title is empty as it was before (without checking there if kodi is playing). But I didn't check this like that.
